### PR TITLE
Fix packed package file contents being read in the wrong encoding

### DIFF
--- a/lib/packages.py
+++ b/lib/packages.py
@@ -162,7 +162,7 @@ class PackageInfo():
             with zipfile.ZipFile(self.package_file()) as zip:
                 info = zip.getinfo(override_file)
                 handle = codecs.EncodedFile(zip.open(info, mode="rU"), "utf-8")
-                content = io.TextIOWrapper(handle).readlines()
+                content = io.TextIOWrapper(handle, encoding="utf-8").readlines()
 
                 source = "Installed Packages" if self.installed_path is not None else "Shipped Packages"
                 source = os.path.join(source, self.name, override_file)


### PR DESCRIPTION
By default, io.TextIOWrapper uses locale.getpreferredencoding(False) as the encoding, which will be different on every system. As the files are always UTF-8, explicitly tell it to use the correct encoding.
Specifically, without this change, problems can occur reading .sublime-menu files, because they contain ellipsis characters which might not be present in the user's locale's default encoding.