### PR TITLE
reuse syntax contexts where possible

### DIFF
--- a/syntax/OverrideAudit-diff.sublime-syntax
+++ b/syntax/OverrideAudit-diff.sublime-syntax
@@ -8,10 +8,16 @@ variables:
 
 contexts:
   main:
+    - include: package_type
+    - include: diff
+
+  package_type:
     - match: '^(\[[SIU ]{3}]) '
       captures:
         1: storage.modifier
       push: package_name
+
+  diff:
     - match: '^    (\w.*)'
       captures:
         1: entity.name.filename.override

--- a/syntax/OverrideAudit-overrideList.sublime-syntax
+++ b/syntax/OverrideAudit-overrideList.sublime-syntax
@@ -1,54 +1,17 @@
 %YAML 1.2
 ---
 name: OverrideAudit
-scope: text.override-audit
+scope: text.override-audit.overridelist
 hidden: true
-variables:
-  pkg_name: '[^<>:"/\\|?*\[\] ][^<>:"/\\|?*\[\]]*?'
 contexts:
   main:
     - match: '^(\[[SIU ]{3}]) '
       captures:
         1: storage.modifier
-      push: package_name
+      push: [package_row, scope:text.override-audit.diff#package_name]
 
     - match: '^WARNING:'
       scope: keyword.control.expired
-
-  package_name:
-    - match: '{{pkg_name}}(?= <.*\[)'
-      scope: entity.name.package.enabled.expired
-      set: check_status
-
-    - match: '{{pkg_name}}(?=\n| <)'
-      scope: entity.name.package.enabled
-      set: check_status
-
-    - match: '(\[)({{pkg_name}})(])(?=.*\[)'
-      captures:
-        1: comment
-        2: entity.name.package.disabled.expired comment
-        3: comment
-      set: check_status
-
-    - match: '(\[)({{pkg_name}})(])'
-      captures:
-        1: comment
-        2: entity.name.package.disabled comment
-        3: comment
-      set: check_status
-
-  check_status:
-    - match: ' (<[\w\s]+>)'
-      captures:
-        1: comment
-
-    - match: ' (\[[\w\s]+])'
-      captures:
-        1: meta.package.expired keyword.control.expired
-
-    - match: '$'
-      set: package_row
 
   package_row:
     - match: '^\s*(`-) (\[X]) (.*)$'

--- a/syntax/OverrideAudit-pkgList.sublime-syntax
+++ b/syntax/OverrideAudit-pkgList.sublime-syntax
@@ -1,7 +1,7 @@
 %YAML 1.2
 ---
 name: OverrideAudit
-scope: text.override-audit
+scope: text.override-audit.pkglist
 hidden: true
 variables:
   pkg_name: '[^<>:"/\\|?*\[\] ][^<>:"/\\|?*\[\]]*?'


### PR DESCRIPTION
This change updates the "override list" syntax to reuse the contexts defined in the "diff" syntax, to avoid unnecessary duplication - thus making it more obvious what changes between the different syntaxes and ensuring future maintenance will be easier.
As an added benefit, the syntaxes now have unique base scope suffixes, so they can be told apart by base scope alone.