### PR TITLE
Fix YAML syntax to allow it to be parsed by Python and .NET

### DIFF
--- a/syntax/OA-OverrideReport.sublime-syntax
+++ b/syntax/OA-OverrideReport.sublime-syntax
@@ -8,7 +8,7 @@ contexts:
     - match: '^(\[[SIU ]{3}]) '
       captures:
         1: storage.modifier
-      push: [package_row, scope:text.override-audit.diff#package_name]
+      push: [package_row, 'scope:text.override-audit.diff#package_name']
 
     - match: '^WARNING:'
       scope: keyword.control.expired


### PR DESCRIPTION
Sublime Text seems to be lax about allowing unquoted `scope:` references in inline-sequences, but Python's YAML parser and the .NET SharpYaml package both choke on this. This PR simply quotes the problematic scalar to work around the problem, with no functional changes. See https://pyyaml.org/wiki/YAMLColonInFlowContext for more details.