### PR TITLE
Fix Open Resource command palette entry not showing all files

### DIFF
--- a/src/commands/create_override.py
+++ b/src/commands/create_override.py
@@ -19,7 +19,7 @@ class OverrideAuditCreateOverrideCommand(sublime_plugin.WindowCommand):
     create an override on save.
     """
     def run(self, package=None, file=None, include_existing=False):
-        # If a packge or file name is missing, prompt for the given item and
+        # If a package or file name is missing, prompt for the given item and
         # reinvoke ourselves. When given a file but no package, the file is
         # ignored and the user will be prompted to pick the file.
         if package is None or file is None:
@@ -33,7 +33,7 @@ class OverrideAuditCreateOverrideCommand(sublime_plugin.WindowCommand):
                 p_filter = lambda p: bool(p.package_file()) and not p.is_disabled
 
             return PackageResourceBrowser(package, file, self.window,
-                res_type, unknown=False, annotate_overrides=annotate,
+                res_type, unknown=include_existing, annotate_overrides=annotate,
                 p_filter=p_filter,
                 on_done=lambda p,r: self.pick(p, r)).browse()
 


### PR DESCRIPTION
In the command palette, OverrideAudit: Open Resource executes command: `override_audit_create_override {"include_existing": true}`
Prior to this commit, it was always firing the `PackageResourceBrowser` with "unknown" set to `False`.
But, as the command palette entry's name indicates, it would be expected to be able to select *any existing* resource from this list - whether it only exists as an extra file in the package or not. (This is important when creating new syntax definitions which extend other ones, for example - they won't exist in the original package, but we still want to see them and open them.)
The solution therefore is to set `unknown` to the value of `include_existing`, to keep it working the same way for other use cases, while fixing the aforementioned command palette entry.