### PR TITLE
Add explicit text legend to the expired audit report

### DIFF
--- a/src/commands/override_report.py
+++ b/src/commands/override_report.py
@@ -38,11 +38,14 @@ class OverrideReportThread(ReportGenerationThread):
         packages = {}
         result = []
         if only_expired:
-            result.append("WARNING: Showing only expired overrides!\n"
-                          "WARNING: Non-expired overrides may exist!\n")
+            result.append("⚠ Showing only expired overrides!\n"
+                          "⚠ Non-expired overrides may exist!\n")
         if exclude_unchanged:
-            result.append("WARNING: Showing only modified overrides!\n"
-                          "WARNING: Overrides with unchanged content may exist!\n")
+            result.append("⚠ Showing only modified overrides!\n"
+                          "⚠ Overrides with unchanged content may exist!\n")
+        result.append("""[S]hipped (core in ST binary) [I]nstalled (in "Installed Packages") [U]npacked (subdir of "Packages")\n"""
+            """[Disabled package] <Dependency>\n"""
+            """🖰› context menu to ignore ("Freshen Expired Overrides in …")\n""")
 
         result.append(self._generation_time())
 


### PR DESCRIPTION
In the rare occasions I get a list of diffs from your automatic report, I'm always puzzled as to what the abbreviations mean and how to suppress them since I don't use it frequently enough to remember

This adds an explicit text legend explaining both.

I know that that there are detailed informative popups on mouseover, but ... you also have to know that this package is cool enough to implement them (and otherwise nothing indicates that that text is actionable)! (last time I've added the patch I thought a PR doesn't make sense due to this, but then recently I've re-discovered the same issue, so think explicit help might be helpful. Also, the right click context menu to suppress is not part of those popups)

